### PR TITLE
src/Room.vue: buttons to join via App (desktop and mobile)

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,10 +1,10 @@
 [main]
-host = https://www.transifex.com
+host     = https://www.transifex.com
 lang_map = bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk, th_TH: th, ja_JP: ja
 
-[nextcloud.jitsi]
+[o:nextcloud:p:nextcloud:r:jitsi]
 file_filter = translationfiles/<lang>/jitsi.po
 source_file = translationfiles/templates/jitsi.pot
 source_lang = en
-type = PO
+type        = PO
 

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -22,6 +22,7 @@ OC.L10N.register(
     "Problems detected" : "Problèmes détectés",
     "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de <b>Firefox/Chrome/Chromium</b>.",
     "Browser not supported" : "Navigateur non compatible",
+    "Show system check" : "Afficher les vérifications systèmes",
     "Your name:" : "Votre nom :",
     "Click here to join" : "Cliquez ici pour rejoindre",
     "Start muted" : "Démarrer micro éteint",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -20,7 +20,7 @@ OC.L10N.register(
     "Conference rooms" : "Salons de conférences",
     "Conference" : "Conférence",
     "Problems detected" : "Problèmes détectés",
-    "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de Firefox/Chrome/Chromium.",
+    "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de <b>Firefox/Chrome/Chromium</b>.",
     "Browser not supported" : "Navigateur non compatible",
     "Your name:" : "Votre nom :",
     "Click here to join" : "Cliquez ici pour rejoindre",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -20,6 +20,7 @@
     "Problems detected" : "Problèmes détectés",
     "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de <b>Firefox/Chrome/Chromium</b>.",
     "Browser not supported" : "Navigateur non compatible",
+    "Show system check" : "Afficher les vérifications systèmes",
     "Your name:" : "Votre nom :",
     "Click here to join" : "Cliquez ici pour rejoindre",
     "Start muted" : "Démarrer micro éteint",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -18,7 +18,7 @@
     "Conference rooms" : "Salons de conférences",
     "Conference" : "Conférence",
     "Problems detected" : "Problèmes détectés",
-    "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de Firefox/Chrome/Chromium.",
+    "Audio and video quality could be poor. It is recommended to use a recent <b>Firefox/Chrome/Chromium</b> version." : "La qualité audio and vidéo pourrait être faible. Il est recommandé d'utiliser une version récente de <b>Firefox/Chrome/Chromium</b>.",
     "Browser not supported" : "Navigateur non compatible",
     "Your name:" : "Votre nom :",
     "Click here to join" : "Cliquez ici pour rejoindre",

--- a/l10n/gl.js
+++ b/l10n/gl.js
@@ -8,6 +8,7 @@ OC.L10N.register(
     "Failed to save settings" : "Produciuse un fallo ao gardar os axustes",
     "Failed to load settings" : "Produciuse un fallo ao cargar os axustes",
     "Conference" : "Conferencia",
+    "Browser not supported" : "Este navegador non é compatíbel",
     "Link copied" : "Ligazón copiada",
     "Cannot copy, please copy the link manually" : "Non foi posíbel copiala. Copie a ligazón manualmente",
     "Copy to clipboard" : "Copiar no portapapeis.",

--- a/l10n/gl.json
+++ b/l10n/gl.json
@@ -6,6 +6,7 @@
     "Failed to save settings" : "Produciuse un fallo ao gardar os axustes",
     "Failed to load settings" : "Produciuse un fallo ao cargar os axustes",
     "Conference" : "Conferencia",
+    "Browser not supported" : "Este navegador non é compatíbel",
     "Link copied" : "Ligazón copiada",
     "Cannot copy, please copy the link manually" : "Non foi posíbel copiala. Copie a ligazón manualmente",
     "Copy to clipboard" : "Copiar no portapapeis.",


### PR DESCRIPTION
This change adds 2 buttons at the bottom of the Room page which allow users to join a Jitsi room via the Jitsi Desktop app and the Jitsi Mobile app, respectively.

The change moves calculations of the corresponding join URLs into `computed()` as the button URLs are required when the page loads. Joining with the desktop app requires the URL to be prefixed with `jitsi-meet://`, while the mobile app requires `http[s]://`.

The "Join using the Jitsi App" section was updated to provide help for joining with the Jitsi app. The calculated join HTTPS URL is re-used there; a user may fall back to pasting this URL into the Jitsi app should the buttons not work for them.

Tested on Linux (Fedora 36) with Chrome (106.0.0.0) and Firefox (105.0), on Windows 11 with Edge (105.0.1343.53) and Firefox (104.0), and on Android 12 with Firefox (105.0) and Chrome (105.0.0.0).

Resolves #8 .

Screenshots
### PC
![nextcloud-jitsi](https://user-images.githubusercontent.com/71888/193021191-5eefeffa-b2be-442a-8e08-c20027b4cdb3.png)

### Android
![nextcloud-jitsi-mobile](https://user-images.githubusercontent.com/71888/193021548-d969ced6-4793-47a7-ae55-0f921cb3d921.jpg)
