### PR TITLE
Fix the "Copy to clipboard" wording translation call in room list

### DIFF
--- a/src/components/RoomListItem.vue
+++ b/src/components/RoomListItem.vue
@@ -81,7 +81,7 @@ export default {
 					? t('jjitsi', this.t('Link copied'))
 					: t('jjitsi', this.t('Cannot copy, please copy the link manually'))
 			}
-			return t('jjitsi', 'Copy to clipboard')
+			return t('jjitsi', this.t('Copy to clipboard'))
 		},
 	},
 	methods: {


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Should call the Transifex translation properly.

This screenshot show the English wording, although my UI is set to French.

![2023-02-27_14-02](https://user-images.githubusercontent.com/33763786/221570751-5319afbf-e77c-43a5-a864-7e4951804fcb.png)
