### PR TITLE
Use lobby if not authenticated.

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -133,6 +133,7 @@ class RoomController extends AbstractController {
 		$context = [
 			'user' => [
 				'name' => $displayName,
+                                'lobby' => $user === null,			
 			],
 		];
 


### PR DESCRIPTION
This PR adds minimal support for #27 by adding the lobby field.

This field is evaluated when the [token_lobby_ondemand](https://github.com/jitsi-contrib/prosody-plugins/tree/main/token_lobby_ondemand) plugin is used in an Jitsi installation. It then sends non-authenticated users into the lobby of the conference room